### PR TITLE
Use a single dockerfile to build both images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+## this is a multi-stage build
+## use --target backend/frontend to specify which stage to build
+## otherwise only frontend builds
+## using alpine and then installing node reduces size from 375MB to 269MB
+FROM alpine AS base
+ENV BACKEND_PORT=3000
+ENV FRONTEND_PORT=5173
+WORKDIR /app
+RUN apk update && apk add npm nodejs~=18
+COPY package*.json ./
+COPY schemas/ schemas/
+RUN npm install
+
+FROM base AS backend
+COPY backend/ backend/
+COPY tsconfig*.json .
+EXPOSE $BACKEND_PORT
+CMD ["npm", "run", "dev:backend"]
+
+FROM base AS frontend
+COPY frontend/ frontend/
+COPY public/ public/
+COPY index.html tsconfig.json vite.config.ts ./
+EXPOSE $FRONTEND_PORT
+CMD ["npm", "run", "dev:frontend"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,17 @@ RUN apk update && apk add npm nodejs~=18
 COPY package*.json ./
 COPY schemas/ schemas/
 RUN npm install
+ENTRYPOINT ["npm", "run"]
 
 FROM base AS backend
 COPY backend/ backend/
-COPY tsconfig*.json .
+COPY tsconfig*.json ./
 EXPOSE $BACKEND_PORT
-CMD ["npm", "run", "dev:backend"]
+CMD ["dev:backend"]
 
 FROM base AS frontend
 COPY frontend/ frontend/
 COPY public/ public/
 COPY index.html tsconfig.json vite.config.ts ./
 EXPOSE $FRONTEND_PORT
-CMD ["npm", "run", "dev:frontend"]
+CMD ["dev:frontend"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     container_name: backend
     build:
       context: .
-      dockerfile: Dockerfile_backend
+      target: backend
     restart: unless-stopped
     volumes:
       - .:/app
@@ -19,7 +19,7 @@ services:
     container_name: frontend
     build:
       context: .
-      dockerfile: Dockerfile_frontend
+      target: frontend
     restart: unless-stopped
     volumes:
       - .:/app


### PR DESCRIPTION
- Uses `Alpine` base image
- Installs node onto the base. This saves ~100MB vs `node:Alpine`
- node is pinned to ~18
- each frontend/backend image gets only the files it needs to work
- Common entrypoint, unique command per image
- ports are defined in `base` image, my thought process was that eventually both sides may need to know both ports