### PR TITLE
HATCH-384: column override functionality

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -9,7 +9,8 @@ import {
 import schemas from "../schemas";
 import {
   DocumentStatus,
-  DocumentActions,
+  DocumentActionsData,
+  DocumentActionsHeader,
   DocumentDate,
   ActionsRow,
 } from "./components/DocumentTable";
@@ -43,17 +44,18 @@ const App: React.FC = () => {
           <DocumentColumn
             type="replace"
             field="dueDate"
-            ValueComponent={DocumentDate}
+            DataValueComponent={DocumentDate}
           />
           <DocumentColumn
             type="replace"
             field="status"
-            ValueComponent={DocumentStatus}
+            DataValueComponent={DocumentStatus}
           />
           <DocumentColumn
             type="append"
             label="Action"
-            ValueComponent={DocumentActions}
+            DataValueComponent={DocumentActionsData}
+            HeaderValueComponent={DocumentActionsHeader}
           />
           <DocumentEmptyList>No records to display</DocumentEmptyList>
         </DocumentList>

--- a/frontend/components/DocumentTable.tsx
+++ b/frontend/components/DocumentTable.tsx
@@ -1,3 +1,4 @@
+import HomeRepairServiceIcon from '@mui/icons-material/HomeRepairService';
 import { Button, Icon, IconButton } from "@mui/material";
 
 export const ActionsRow: React.FC<{
@@ -78,7 +79,7 @@ export function DocumentStatus({ value, record, attributeSchema }: any) {
   );
 }
 
-export function DocumentActions({ record }: any) {
+export function DocumentActionsData({ record }: any) {
   return (
     <>
       <IconButton
@@ -96,5 +97,24 @@ export function DocumentActions({ record }: any) {
         visibility
       </IconButton>
     </>
+  );
+}
+
+export function DocumentActionsHeader({column}: any) {
+  return (
+    <div
+      style={{
+        alignItems: "center",
+        display: "flex",
+        gap: "5px"
+      }}
+    >
+      <strong>{column.label}</strong>
+      <HomeRepairServiceIcon
+        sx={{
+          transform: "translateY(-2px)"
+        }}
+      />
+    </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@hatchifyjs/core": "^0.3.4",
         "@hatchifyjs/express": "^1.1.1",
         "@hatchifyjs/koa": "^1.1.1",
-        "@hatchifyjs/react": "^0.1.24",
+        "@hatchifyjs/react": "^0.1.26",
         "@koa/cors": "^4.0.0",
         "commander": "^11.0.0",
         "cors": "^2.8.5",
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.1.tgz",
+      "integrity": "sha512-QgcKYwzcc8vvZ4n/5uklchy8KVdjJwcOeI+HnnTNclJjs2nYsy23DOCf+sSV1kBwD9yDAoVKCkv/gEPzgQU3Pw==",
       "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.1.3"
@@ -749,11 +749,11 @@
       "integrity": "sha512-NLkn+gRchrWSXDTZlfsAyYE6ne7DjWl5Nx6I1aipLq1En7v5kt3WGrQavuLkH/BRde9wspC/iG3DHWexwVHAdQ=="
     },
     "node_modules/@hatchifyjs/design-mui": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/design-mui/-/design-mui-0.1.27.tgz",
-      "integrity": "sha512-feFCMWu6Y3F8bunxiqDlp+PgT00ems7wsavCrLCzQvDf0BNaLVsupYqrFw6f/smqnCUdcPTxQjDYth7Z/kmdNw==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/design-mui/-/design-mui-0.1.29.tgz",
+      "integrity": "sha512-OuJQfEHXe4qVnMlVwU9Kya8dS8HcfL9APuWyLjrY8gT5H+2BqsYiIhuK/blO8Gm/BvgaGP/zBCI4HXzc1+2mIA==",
       "dependencies": {
-        "@hatchifyjs/react-ui": "^0.1.20",
+        "@hatchifyjs/react-ui": "^0.1.22",
         "@mui/icons-material": "^5.14.1",
         "@mui/utils": "^5.13.1",
         "lodash": "^4.17.21"
@@ -820,12 +820,12 @@
       }
     },
     "node_modules/@hatchifyjs/react": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/react/-/react-0.1.24.tgz",
-      "integrity": "sha512-0t8pUJmX8MvcI2xyhaRZKNa9YfcmKRKNkJKEh4v3k+sqaeof97SGyTIzEPpmCjwlpYYhZ3J7Kc3bYGY1ByXf2A==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/react/-/react-0.1.26.tgz",
+      "integrity": "sha512-LhOiMsphsmQaUKPQrc+Zf9mbh3rglj8PAqd91El1dnteEuHEhSJiL/l/r2sl+B/xsiuJCXPu36LdH7QoQB3Yvw==",
       "dependencies": {
-        "@hatchifyjs/design-mui": "^0.1.27",
-        "@hatchifyjs/react-ui": "^0.1.20",
+        "@hatchifyjs/design-mui": "^0.1.29",
+        "@hatchifyjs/react-ui": "^0.1.22",
         "@hatchifyjs/rest-client-jsonapi": "^0.1.11"
       },
       "peerDependencies": {
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@hatchifyjs/react-ui": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/react-ui/-/react-ui-0.1.20.tgz",
-      "integrity": "sha512-F8wXcaR5qptguxOm5AtJwB+9q731+9nhGghDqXInpRTVZ3MgE7Fn6cQlvnNUNQ1K8IbQsUt3BlneqvlEQLwjEw==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/react-ui/-/react-ui-0.1.22.tgz",
+      "integrity": "sha512-3mX0cOihijHCOnC0uGYeSF1m0KB0VKlF+XExNL30UESjUUhCqlzQhkFeN/WxMyBej21UrH48A8KXWIGtO0N0nQ==",
       "dependencies": {
         "@hatchifyjs/react-rest": "^0.1.11",
         "@hatchifyjs/rest-client": "^0.1.9"
@@ -1337,9 +1337,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.0.tgz",
-      "integrity": "sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
+      "integrity": "sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==",
       "peer": true,
       "engines": {
         "node": ">=14.0.0"
@@ -6615,12 +6615,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.0.tgz",
-      "integrity": "sha512-pVvzsSsgUxxtuNfTHC4IxjATs10UaAtvLGVSA1tbUE4GDaOSU1Esu2xF5nWLz7KPiMuW8BJWuPFdlGYJ7/rW0w==",
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.1.tgz",
+      "integrity": "sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.13.0"
+        "@remix-run/router": "1.13.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6630,13 +6630,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.0.tgz",
-      "integrity": "sha512-CbcKjEyiSVpA6UtCHOIYLUYn/UJfwzp55va4yEfpk7JBN3GPqWfHrdLkAvNCcpXr8QoihcDMuk0dzWZxtlB/mQ==",
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.1.tgz",
+      "integrity": "sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.13.0",
-        "react-router": "6.20.0"
+        "@remix-run/router": "1.13.1",
+        "react-router": "6.20.1"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@hatchifyjs/core": "^0.3.4",
     "@hatchifyjs/express": "^1.1.1",
     "@hatchifyjs/koa": "^1.1.1",
-    "@hatchifyjs/react": "^0.1.24",
+    "@hatchifyjs/react": "^0.1.26",
     "@koa/cors": "^4.0.0",
     "commander": "^11.0.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
Adding bare-bones demonstration of functionality introduced in [HATCH-384](https://github.com/bitovi/hatchify/pull/344), i.e. the ability to override column headers.

<img width="348" alt="Screenshot 2023-12-04 at 4 13 32 PM" src="https://github.com/bitovi/hatchify-grid-demo/assets/60432429/b5ea7ced-f211-40d5-b4c3-e0f563461983">

[HATCH-384]: https://bitovi.atlassian.net/browse/HATCH-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ