### PR TITLE
Hatch-462: Limit amount of text displayed in grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@hatchifyjs/core": "^0.3.6",
+        "@hatchifyjs/core": "^0.3.7",
         "@hatchifyjs/express": "^1.3.6",
         "@hatchifyjs/koa": "^1.3.6",
-        "@hatchifyjs/react": "^0.1.34",
+        "@hatchifyjs/react": "^0.1.35",
         "@mui/material": "^5.15.0",
         "commander": "^11.1.0",
         "express": "^4.18.2",
@@ -1057,16 +1057,16 @@
       "optional": true
     },
     "node_modules/@hatchifyjs/core": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/core/-/core-0.3.6.tgz",
-      "integrity": "sha512-QKiwBvuGucqaaimTlGqbCPUyahtR8NoN5HMTjYuStw486rKnmpC4DVkqi60dRnxcA6qOVWPGwX+2tZBKDdi3zg=="
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/core/-/core-0.3.7.tgz",
+      "integrity": "sha512-CnzDvPHvlvybyC0B9/uCqgBXt1UXe9ffa/YB8JUQdnofzIUM3JxqOL/snOHs24otrfcvs674osksSlvS5OZzbQ=="
     },
     "node_modules/@hatchifyjs/design-mui": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/design-mui/-/design-mui-0.1.36.tgz",
-      "integrity": "sha512-bnr7qWkh3PkBYFcJTpBSJH9KpoQwsfIZlfH3szcxGK6VfpZYmipATXnnRfQBeg6FICUMWVbTdrVIu/IGRl7Opg==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/design-mui/-/design-mui-0.1.37.tgz",
+      "integrity": "sha512-6Ii8/8IW8lWuRR5VYEybO73S7/7besyxUUNNkfKyMzkblaPET110F/EZRGbZF3HhXlOc37GH4aSqijDTlrH9mQ==",
       "dependencies": {
-        "@hatchifyjs/react-ui": "^0.1.26",
+        "@hatchifyjs/react-ui": "^0.1.27",
         "@mui/icons-material": "^5.14.1",
         "@mui/utils": "^5.13.1",
         "lodash": "^4.17.21"
@@ -1132,12 +1132,12 @@
       }
     },
     "node_modules/@hatchifyjs/react": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/react/-/react-0.1.34.tgz",
-      "integrity": "sha512-BfCjZ38Or5VKt6opXEcx2rYYyXYul7PLOo07joPSjyBjJot9OjnzwZatnLBHXdew3AucYrbLmVJlxBA1/HMSmw==",
+      "version": "0.1.35",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/react/-/react-0.1.35.tgz",
+      "integrity": "sha512-9ltbnibVl7GZTCcdSEUj7osUifX8/SsskAj4b5JM/FRjWGtyb54BITMMfILn/U6J9c8fOaR5i5hOQ08pHv8MLg==",
       "dependencies": {
-        "@hatchifyjs/design-mui": "^0.1.36",
-        "@hatchifyjs/react-ui": "^0.1.26",
+        "@hatchifyjs/design-mui": "^0.1.37",
+        "@hatchifyjs/react-ui": "^0.1.27",
         "@hatchifyjs/rest-client-jsonapi": "^0.1.15"
       },
       "peerDependencies": {
@@ -1160,9 +1160,9 @@
       }
     },
     "node_modules/@hatchifyjs/react-ui": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/react-ui/-/react-ui-0.1.26.tgz",
-      "integrity": "sha512-uf8O2i1WeDpPKYKwZPB0bdegTZhywBMytpQX9RGrf/iRZMPtBA9MVLnoGcVwev3Y/pbpURaEw19Zwh8/Hc9BdA==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/react-ui/-/react-ui-0.1.27.tgz",
+      "integrity": "sha512-JCUgpr6QH41d1q0aikDVXDEf2Wry/WECC3hT+CxoouN/Bepkha96XdxYQIuul8/pkL7+HHYd1FLi5PX8mDc88g==",
       "dependencies": {
         "@hatchifyjs/react-rest": "^0.1.15",
         "@hatchifyjs/rest-client": "^0.1.12"

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@hatchifyjs/core": "^0.3.6",
+    "@hatchifyjs/core": "^0.3.7",
     "@hatchifyjs/express": "^1.3.6",
     "@hatchifyjs/koa": "^1.3.6",
-    "@hatchifyjs/react": "^0.1.34",
+    "@hatchifyjs/react": "^0.1.35",
     "@mui/material": "^5.15.0",
     "commander": "^11.1.0",
     "express": "^4.18.2",

--- a/schemas.ts
+++ b/schemas.ts
@@ -19,7 +19,7 @@ export const Document: PartialSchema = {
     dueDate: dateonly(),
     importance: integer(),
     lastUpdated: datetime(),
-    notes: text(),
+    notes: text({ maxRenderLength: 80 }),
     complete: boolean(),
     uuid: uuid(),
     status: enumerate({ values: ["Pending", "Failed", "Completed"] }),


### PR DESCRIPTION
Adding simple demonstration of functionality introduced in [HATCH-462](https://github.com/bitovi/hatchify/pull/375), i.e. setting a `maxRenderLength` for `string` and `text` attributes.

<img width="232" alt="Screenshot 2023-12-18 at 5 25 21 PM" src="https://github.com/bitovi/hatchify-grid-demo/assets/60432429/bf02fe2e-ffae-4088-9013-9cf2ca4bcdce">


[HATCH-462]: https://bitovi.atlassian.net/browse/HATCH-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ